### PR TITLE
Feat/improve ux 8

### DIFF
--- a/R/drawCell.R
+++ b/R/drawCell.R
@@ -18,22 +18,20 @@
 #' @export
 #'
 #' @examples
-#' drawCell(taxonomy_id = '58334',
-#' sl_ids = '0049',
-#' size = 2000,
-#' color = 'lightblue')
-#' <Add Title>
-#'
-#' <Add Description>
-drawCell <- function(organism_identifier, sl_ids, inputId = NULL, width = NULL, height = NULL, elementId = NULL, colour_sl = NULL) {
+#' drawCell(
+#'    organism_identifier = '9606',
+#'    list_sl_colors = list(
+#'    'SL0095' = 'green',
+#'    'SL0154'='red')
+#'  )
+drawCell <- function(organism_identifier, list_sl_colors,  width = NULL, height = NULL) {
 
-  
   # forward options using x
   x = list(
-    input_id = inputId,
+    input_id = "cell",
     organism_identifier = organism_identifier,
-    sl_ids = csl(sl_ids),
-    colour_sl = csl(colour_sl)
+    sl_ids = csl(names(list_sl_colors)),
+    colour_sl = csl(list_sl_colors)
   )
   # create widget
   htmlwidgets::createWidget(
@@ -42,6 +40,6 @@ drawCell <- function(organism_identifier, sl_ids, inputId = NULL, width = NULL, 
     width = width,
     height = height,
     package = 'drawCell',
-    elementId = elementId
+    elementId = NULL
   )
 }

--- a/inst/shinyApp/drawCellShiny/server.R
+++ b/inst/shinyApp/drawCellShiny/server.R
@@ -21,26 +21,31 @@ function(input, output){
   })
   
   sc_id = reactiveVal()
-  sc_id_to_select = reactiveVal()
-  colours_vector = reactiveVal("#56B4E9")
-  
+
+  subcelular_colours <- reactiveVal(list("SL0000" = "#56B4E9"))
+
   output$cell_output = drawCell::renderDrawCell({
     
-    drawCell(taxonomy_id(),
-             sc_id_to_select(),
-             inputId = "cell",
-             colour_sl = colours_vector())
+    drawCell(organism_identifier = taxonomy_id(),
+             list_sl_colors = subcelular_colours())
   })
 
   observeEvent(input$cell_click,{
     sc_id(substr(input$cell_click, 3, 6))
-    sc_id_to_select(c(sc_id_to_select(), input$cell_click))
-    colours_vector(c(colours_vector(), input$colourInput))
+    
+    list_named_colours <- c(subcelular_colours(), input$colourInput)
+    names(list_named_colours)[length(list_named_colours)] <- input$cell_click
+    subcelular_colours(list_named_colours)
   })
   
+  observeEvent(input$colourInput,{
+    list_named_colours <- subcelular_colours()
+    list_named_colours[length(list_named_colours)] <- input$colourInput
+    subcelular_colours(list_named_colours)
+  })
+
   observeEvent(input$cell_type, {
     sc_id(NULL)
-    sc_id_to_select('SL0000')
   })
   
   output$cell_s_output <- renderText({


### PR DESCRIPTION
I added two main features in this PR:

1. The input for the main function `drawCell()` is a named list with the colors and subcellular locations, this seems easier and less error prone.
```
drawCell(organism_identifier = '9060', list_sl_colors = list("SL0173" = "red", "SL0101" = "blue"))
```
2. In the Shiny app, the user can now click on a organelle, and adjust its colour with the palette widget.


https://user-images.githubusercontent.com/71273913/199524985-074cf9a9-d81d-4767-ae8c-1593bd85c456.mov


It also closes #8 