### PR TITLE
feat: The download button now is functional.

### DIFF
--- a/inst/shinyApp/drawCellShiny/server.R
+++ b/inst/shinyApp/drawCellShiny/server.R
@@ -6,7 +6,6 @@ function(input, output) {
           sci_com = input$taxIdInput,
           db = "ncbi"
         )
-
         taxonomy_id <- as.numeric(taxonomy_id$ncbi[1])
       } else {
         taxonomy_id <- as.numeric(input$taxIdInput)
@@ -157,15 +156,18 @@ function(input, output) {
   })
 
   observeEvent(input$clipbtn,{
-    toast("Code copied to clipboard", class = "center aligned basic", id = "code_copied_message")
+    toast("Code copied to clipboard", class = "center aligned basic toast_message", id = "code_copied_message")
   })
 
+  output$download_cell <- downloadHandler(
+    filename = "cell_picture.png",
+    content = function(file) {
+      toast("Preparing your image...", class = "center aligned basic toast_message", id = "cell_image_message")
 
-  # output$download_plot <- downloadHandler(
-  #   filename = "Shinyplot.png",
-  #   content = function(file) {
-  #     png(file)
-  #     print('hi')
-  #     drawcell_plot()
-  #   })
+      temp_png <- tempfile(fileext = ".png")
+      temp_html <- tempfile(fileext = ".html")
+      htmlwidgets::saveWidget(drawcell_plot(), file = temp_html)
+      webshot2::webshot(temp_html,file = temp_png)
+      file.copy(temp_png, file)
+    })
 }

--- a/inst/shinyApp/drawCellShiny/ui.R
+++ b/inst/shinyApp/drawCellShiny/ui.R
@@ -103,7 +103,7 @@ semanticPage(
             ),
             segment(
               class = "compact padded no_box",
-              button(
+              downloadButton(
                 "download_cell",
                 label = "Download Cell",
                 icon = icon("download"),

--- a/inst/shinyApp/drawCellShiny/www/styles.css
+++ b/inst/shinyApp/drawCellShiny/www/styles.css
@@ -71,7 +71,7 @@
   font-size: 80px !important;
 }
 
-#code_copied_message {
+.toast_message {
   font-size: 1.5rem !important;
 	color: #009c95 !important;
 	border: 1px solid #009c95 !important;
@@ -80,4 +80,12 @@
 
 #cell_output {
   min-width: 35rem;
+}
+
+#download_cell {
+  display: block !important;
+	color: #009c95 !important;
+	border: 1px solid #009c95 !important;
+  text-align: center;
+  padding: .78571429em 1.5em .78571429em !important;
 }


### PR DESCRIPTION
Functional download button based on webshot2. 
I couldn't find an easy solution to transform a html element such as shinyWidget to a png. There is a big discussion going around this: see [this](https://stackoverflow.com/questions/35056733/how-to-capture-html-output-as-png-in-r) or [this](https://github.com/ramnathv/htmlwidgets/issues/95). 

I tried to use (shinyscreenshot)[https://github.com/daattali/shinyscreenshot] but as the author points, it might not work with `htmlWidget` and that was my case, the part where the cell was, was empty. And when using the selector the div of the cell, it returned an empty image.
![shinyscreenshot](https://user-images.githubusercontent.com/71273913/200355385-e0bebb5d-9450-47c9-9c36-17d3fbeecd3f.png).

I realized that `knitr` was actually creating an PNG out of the function `drawCell()` to create the document for the github README. I dig into how this was happening and when knitr finds an htmlWidget it saves it as html and then takes a screenshot of it. I decided to do the same and it works.