### PR TITLE
Feat: Cell type selection gets disabled when taxonomy ID input is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     htmlwidgets,
     shiny,
     shiny.semantic,
+    shinyjs,
     taxize,
     webshot2,
     Rcpp,

--- a/inst/shinyApp/drawCellShiny/server.R
+++ b/inst/shinyApp/drawCellShiny/server.R
@@ -2,6 +2,11 @@ function(input, output) {
   observeEvent(input$taxIdInput, {
     if (input$taxIdInput == "") {
       shinyjs::enable("cell_type")
+      updateSelectInput(
+        session = getDefaultReactiveDomain(),
+        inputId = "cell_type",
+        selected = "Animal cell"
+      )
     } else {
       shinyjs::disable("cell_type")
       updateSelectInput(

--- a/inst/shinyApp/drawCellShiny/server.R
+++ b/inst/shinyApp/drawCellShiny/server.R
@@ -1,4 +1,18 @@
 function(input, output) {
+  observeEvent(input$taxIdInput, {
+    if (input$taxIdInput == "") {
+      shinyjs::enable("cell_type")
+    } else {
+      shinyjs::disable("cell_type")
+      updateSelectInput(
+        session = getDefaultReactiveDomain(),
+        inputId = "cell_type",
+        selected = ""
+      )
+    }
+  })
+
+
   taxonomy_id <- reactive({
     if (input$cell_type == "") {
       if (is.na(as.numeric(input$taxIdInput))) {
@@ -157,21 +171,24 @@ function(input, output) {
 
   observeEvent(input$clipbtn, {
     toast("Code copied to clipboard",
-          class = "center aligned basic toast_message",
-          id = "code_copied_message")
+      class = "center aligned basic toast_message",
+      id = "code_copied_message"
+    )
   })
 
   output$download_cell <- downloadHandler(
     filename = "cell_picture.png",
     content = function(file) {
       toast("Preparing your image...",
-            class = "center aligned basic toast_message",
-            id = "cell_image_message")
+        class = "center aligned basic toast_message",
+        id = "cell_image_message"
+      )
 
       temp_png <- tempfile(fileext = ".png")
       temp_html <- tempfile(fileext = ".html")
       htmlwidgets::saveWidget(drawcell_plot(), file = temp_html)
       webshot2::webshot(temp_html, file = temp_png)
       file.copy(temp_png, file)
-    })
+    }
+  )
 }

--- a/inst/shinyApp/drawCellShiny/ui.R
+++ b/inst/shinyApp/drawCellShiny/ui.R
@@ -4,6 +4,7 @@ semanticPage(
   titlePanel(
     title = div(
       class = "ui massive fluid teal right icon label",
+      id = "title_label",
       "drawCell",
       a(
         icon(class = "big github square"),

--- a/inst/shinyApp/drawCellShiny/ui.R
+++ b/inst/shinyApp/drawCellShiny/ui.R
@@ -19,7 +19,7 @@ semanticPage(
     segment(
       class = "padded no_box",
       div(
-        class = "ui horizontal stackable segments centered_content no_box",
+        class = "ui horizontal stackable segments centered_content",
         segment(
           class = "compact padded no_box min_width_input",
           selectInput(

--- a/inst/shinyApp/drawCellShiny/ui.R
+++ b/inst/shinyApp/drawCellShiny/ui.R
@@ -1,5 +1,6 @@
 semanticPage(
   includeCSS("www/styles.css"),
+  shinyjs::useShinyjs(),
   # Application title
   titlePanel(
     title = div(

--- a/inst/shinyApp/drawCellShiny/www/styles.css
+++ b/inst/shinyApp/drawCellShiny/www/styles.css
@@ -42,6 +42,10 @@
   font-size: 1.5rem !important;
 }
 
+#cell_type {
+  min-width: 20rem !important;
+}
+
 #cell_sl_color, .min_width_input {
   min-width: 22rem !important;
 }

--- a/inst/shinyApp/drawCellShiny/www/styles.css
+++ b/inst/shinyApp/drawCellShiny/www/styles.css
@@ -12,8 +12,13 @@
   justify-content: center;
   display: flex;
 }
+
+#title_label {
+  font-size: 2.5rem !important;
+}
+
 .ui {
-    font-size: 2rem !important;
+    font-size: 1.25rem !important;
 }
 
 .no_box {
@@ -29,12 +34,12 @@
 .ui.input {
   display: grid;
   margin: 0 5em 1em;
-  font-size: 2rem !important;
+  font-size: 1.5rem !important;
 }
 
 .ui.form {
   margin: 0 5em 1em;
-  font-size: 2rem !important;
+  font-size: 1.5rem !important;
 }
 
 #cell_sl_color, .min_width_input {
@@ -42,14 +47,14 @@
 }
 
 .ui.small.compact.table.dataTable.no-footer {
-  font-size: 1.25rem !important;
+  font-size: 1rem !important;
 }
 .ui.form, .ui.form .field .dropdown, .ui.form .field .dropdown .menu > .item {
-	font-size: 2rem !important;
+	font-size: 1.5rem !important;
 }
 
 #DataTables_Table_0 {
-  font-size: 1.5rem !important;
+  font-size: 1.25rem !important;
 }
 
 .ui.table > thead > tr > th {


### PR DESCRIPTION
* Uses `shinyjs` to disable cell type selection when taxonomy ID starts to get an input.
* Cell type selection remains disabled until taxonomy ID input is removed.
* Builds on PR #22, so that must be resolved  before this.